### PR TITLE
Remove stream-readable dependency

### DIFF
--- a/lib/pass-stream.js
+++ b/lib/pass-stream.js
@@ -3,23 +3,7 @@
 var Stream = require('stream');
 var util = require('util');
 
-/*
- * I found an issue with falsey values which I am waiting for
- * a few pull requests to node and readable-stream, so in the
- * meantime use the patched version from my repo
- *
- * https://github.com/isaacs/readable-stream/pull/55
- * https://github.com/joyent/node/pull/5181
-
-// node 0.10+ has Transform stream so use it if available
-// otherwise use readable-stream module
-var Transform = (Stream.Transform) ?
-  Stream.Transform :
-  require('readable-stream').Transform;
-
- */
-
-var Transform = require('readable-stream').Transform;
+var Transform = Stream.Transform;
 
 function PassThroughExt(writeFn, endFn, options) {
   if (!(this instanceof PassThroughExt)) {

--- a/package.json
+++ b/package.json
@@ -18,11 +18,9 @@
   ],
   "main": "lib/pass-stream",
   "engines": {
-    "node": ">=0.8"
+    "node": ">=0.10"
   },
-  "dependencies": {
-    "readable-stream": "https://github.com/jeffbski/readable-stream/archive/v1.0.2-object-transform2-ret-self.tar.gz"
-  },
+  "dependencies": {},
   "devDependencies": {
     "mocha": "~1.9.0",
     "chai": "~1.5.0",


### PR DESCRIPTION
This package originally depended a patched package called `readable-stream`. That functionality is now in Node core. At the time of this writing, Node 0.10 is past its End of Life, and so there is no need to keep using `readable-stream`.

We had an Enterprise client that couldn't use `digest-stream` because it depended on this package, which references an archive on GitHub (because it was a patched version) and this was causing problems with their firewall. With this update, we'd be able to use `digest-stream` wholesale.

All tests still pass after this change.

Tested on:
- **v0.10.48** (just in case you still wanted to support 0.10)
- **v4.8.0** (current LTS Argon)
- **v6.10.0** (current LTS Boron)